### PR TITLE
Enables the switch on 2 different variants

### DIFF
--- a/code/vtblmap4.hpp
+++ b/code/vtblmap4.hpp
@@ -536,6 +536,8 @@ public:
     }
 
     template <typename S1> inline T& xtl_get(const S1* s1) { intptr_t vtbl[1] = {vtbl_of(s1)}; return get(vtbl); } // FIX: temporary XTL experiment
+    
+    template <typename S1, typename S2> inline auto xtl_get(const S1* s1, const S2* s2) -> T& { intptr_t vtbl[2] = {vtbl_of(s1),vtbl_of(s2)}; return get(vtbl); }
 
   //template <typename S1> inline auto get(const S1* s1) -> typename std::enable_if<!std::is_polymorphic<S1>::value,T&>::type { static T dummy; return dummy; }
     template <typename S1> inline auto get(const S1* s1) -> typename std::enable_if< std::is_polymorphic<S1>::value,T&>::type { intptr_t vtbl[1] = {vtbl_of(s1)}; return get(vtbl); }


### PR DESCRIPTION
So that the following use-case works:

void test(variant<X, Y, Z> vx, variant<M, N> vm)
{
    var<X> x; var<Y> y; var<Z> z;
    var<M> m; var<N> n;

```
Match(vx, vm)
{
    Case(C<X>(x), C<M>(m)) use(x, m);
    Case(C<Y>(y), C<M>(m)) use(y, m);
    // etc.
}
EndMatch
```

}
