### PR TITLE
include header <utility>

### DIFF
--- a/code/xtl.hpp
+++ b/code/xtl.hpp
@@ -46,6 +46,7 @@
 #pragma once
 
 #include <type_traits>
+#include <utility>
 #include "config.hpp"	// To emulate some of the language features on old compilers
 
 namespace xtl


### PR DESCRIPTION
file xtl.hpp uses std::forward but does not include header <utility>. This causes a compiler error on my GCC 4.8.2 on Windows (MinGW) when I include single header type_switchN-patterns-xtl.hpp