### PR TITLE
mch::var<T&> is not convertible to T&

### DIFF
--- a/code/mach7/patterns/primitive.hpp
+++ b/code/mach7/patterns/primitive.hpp
@@ -380,7 +380,7 @@ struct var<T&>
     /// \note If you get assertion here, it means you are trying to use the 
     ///       value of this reference variable before it was bound (i.e. used 
     ///       in pattern matching context to get its value).
-    operator const result_type&() const noexcept { XTL_ASSERT(m_value); return *m_value; }
+    operator T&() const noexcept { XTL_ASSERT(m_value); return *m_value; }
 
     /// Member that will hold matching value in case of successful matching
     mutable T* m_value;


### PR DESCRIPTION
Playing with your example, I found that the following does not compile:

```c++
#include <mach7/type_switchN-patterns-xtl.hpp>
#include <mach7/adapters/boost/adapt_boost_variant.hpp>
#include <mach7/patterns/constructor.hpp>                // for mch::C
#include <mach7/patterns/primitive.hpp>                  // for mch::var

struct TankA { int vol = 0; };
struct TankX { };
using  Tank = boost::variant<TankA, TankX>;

namespace mch
{
  template <> struct bindings<TankA> { Members(TankA::vol); };
}

void modify_vol(int& v) { v = 3; }
void read_vol(int const&) { }

void modify(Tank & tank)
{
  mch::var<int&> vol;

  Match(tank)
  {
    Case(mch::C<TankA>(vol))
      modify_vol(vol);  // ERROR: cannot convert var<T&> to T&
                        // read_vol(vol); works fine
  }
  EndMatch
}

int main()
{
  Tank t = TankA();
  modify(t);
  assert(boost::get<TankA>(t).vol == 3);
}
```

Given that the intent for `var<int&>` is to emulate `T&`, and that a similar conversion works for `var<T>`, I guess this is an omission.