### PR TITLE
mch::address to also work for smart pointers

### DIFF
--- a/code/mach7/patterns/address.hpp
+++ b/code/mach7/patterns/address.hpp
@@ -71,8 +71,7 @@ struct address
     template <typename S> struct accepted_type_for; // Intentionally no definition
     template <typename S> struct accepted_type_for<S*> { typedef typename P1::template accepted_type_for<S>::type* type; };
 
-    template <typename T> bool operator()(const T* t) const { return t && m_p1(*t); }
-    template <typename T> bool operator()(      T* t) const { return t && m_p1(*t); }
+    template <typename T> bool operator()(T&& t) const { return t && m_p1(*std::forward<T>(t)); }
 
     P1 m_p1;
 };


### PR DESCRIPTION
[This unit test](https://github.com/solodon4/Mach7/blob/master/code/test/unit/example04.cpp#L104-L120) shows how to use `mch::address` matcher with raw pointers. However, if I change raw pointers to `std::unique_ptr` (a good practice, isn't it?) the test no longer compiles.

The proposed change makes the matcher work with any dereferencable type: smart pointers and `boost::optional`.
