### PR TITLE
Silenced MSCV warning C4800

### DIFF
--- a/code/mach7/type_switchN-patterns-xtl.hpp
+++ b/code/mach7/type_switchN-patterns-xtl.hpp
@@ -148,7 +148,7 @@ struct type_switch_info_offset_helper<false, SwitchInfo>
         auto const subject_ptr##N = mch::addr(subject_ref##N);                 \
         typedef XTL_CPP0X_TYPENAME mch::underlying<decltype(*subject_ptr##N)>::type source_type##N; \
         typedef source_type##N target_type##N XTL_UNUSED_TYPEDEF;              \
-        XTL_ASSERT(xtl_failure("Trying to match against a nullptr",subject_ptr##N));      \
+        XTL_ASSERT(xtl_failure("Trying to match against a nullptr",subject_ptr##N != nullptr));      \
         enum { is_polymorphic##N = xtl::is_poly_morphic<source_type##N>::value, \
                polymorphic_index##N = XTL_CONCAT(polymorphic_index,XTL_PREV(N)) + is_polymorphic##N }; \
         auto& match##N = *subject_ptr##N;                                      \

--- a/code/mach7/type_switchN-patterns.hpp
+++ b/code/mach7/type_switchN-patterns.hpp
@@ -148,7 +148,7 @@ struct type_switch_info_offset_helper<false, SwitchInfo>
         auto const subject_ptr##N = mch::addr(subject_ref##N);                 \
         typedef XTL_CPP0X_TYPENAME mch::underlying<decltype(*subject_ptr##N)>::type source_type##N; \
         typedef source_type##N target_type##N XTL_UNUSED_TYPEDEF;              \
-        XTL_ASSERT(xtl_failure("Trying to match against a nullptr",subject_ptr##N)); \
+        XTL_ASSERT(xtl_failure("Trying to match against a nullptr",subject_ptr##N != nullptr)); \
         enum { is_polymorphic##N = std::is_polymorphic<source_type##N>::value, \
                polymorphic_index##N = XTL_CONCAT(polymorphic_index,XTL_PREV(N)) + is_polymorphic##N }; \
         auto& match##N = *subject_ptr##N;                                      \


### PR DESCRIPTION
Truncation of pointer to `bool` caused level-3 warning on MSVC. 