### PR TITLE
Fix #79

### DIFF
--- a/code/mach7/type_switchN-patterns-xtl.hpp
+++ b/code/mach7/type_switchN-patterns-xtl.hpp
@@ -271,3 +271,4 @@ struct type_switch_info_offset_helper<false, SwitchInfo>
         }
 
 //------------------------------------------------------------------------------
+#undef dynamic_cast


### PR DESCRIPTION
Dangling `#define dynamic_cast` was polluting including files.